### PR TITLE
gh-27: Remove unsafe verification step

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cyphr
 Title: High Level Encryption Wrappers
-Version: 1.0.3
+Version: 1.0.4
 Authors@R: person("Rich", "FitzJohn", role = c("aut", "cre"),
     email = "rich.fitzjohn@gmail.com")
 Description: Encryption wrappers, using low-level support from

--- a/tests/testthat/test-zzz-data.R
+++ b/tests/testthat/test-zzz-data.R
@@ -77,9 +77,6 @@ test_that("grant access", {
   expect_identical(dat_req$host, Sys.info()[["nodename"]])
   expect_identical(dat_req$user, Sys.info()[["user"]])
   expect_is(dat_req$date, "POSIXt")
-  expect_true(openssl::signature_verify(data_key_prep(dat_req),
-                                        dat_req$signature,
-                                        pubkey = dat_req$pub))
 
   ## Try loading requests:
   keys <- data_load_request(path, NULL, quiet)


### PR DESCRIPTION
This buys little, and it is not stable across R versions etc. The
best security we get is out-of-band distribution of keys

Fixes #27