### PR TITLE
gh-23: Look recursively for the root directory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Suggests:
     knitr,
     rmarkdown,
     testthat
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 VignetteBuilder: rmarkdown,
     knitr
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cyphr
 Title: High Level Encryption Wrappers
-Version: 1.0.4
+Version: 1.0.5
 Authors@R: person("Rich", "FitzJohn", role = c("aut", "cre"),
     email = "rich.fitzjohn@gmail.com")
 Description: Encryption wrappers, using low-level support from

--- a/R/util.R
+++ b/R/util.R
@@ -140,3 +140,7 @@ prompt_confirm <- function(msg = "continue?", valid = c(n = FALSE, y = TRUE),
 read_line <- function(prompt) {
   readline(prompt = prompt) # nocov
 }
+
+`%||%` <- function(a, b) {
+  if (is.null(a)) b else a
+}

--- a/man/cyphr.Rd
+++ b/man/cyphr.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{cyphr}
 \alias{cyphr}
-\alias{cyphr-package}
 \title{High Level Encryption Wrappers}
 \description{
 Encryption wrappers, using low-level support from sodium and openssl.

--- a/man/data_admin.Rd
+++ b/man/data_admin.Rd
@@ -9,16 +9,23 @@
 \usage{
 data_admin_init(path_data, path_user = NULL, quiet = FALSE)
 
-data_admin_authorise(path_data, hash = NULL, path_user = NULL,
-  yes = FALSE, quiet = FALSE)
+data_admin_authorise(
+  path_data = NULL,
+  hash = NULL,
+  path_user = NULL,
+  yes = FALSE,
+  quiet = FALSE
+)
 
-data_admin_list_requests(path_data)
+data_admin_list_requests(path_data = NULL)
 
-data_admin_list_keys(path_data)
+data_admin_list_keys(path_data = NULL)
 }
 \arguments{
 \item{path_data}{Path to the data set.  We will store a bunch of
-things in a hidden directory within this path.}
+things in a hidden directory within this path.  By default in
+most functions we will search down the tree until we find the
+.cyphr directory}
 
 \item{path_user}{Path to the directory with your ssh key.
 Usually this can be omitted.}

--- a/man/data_user.Rd
+++ b/man/data_user.Rd
@@ -5,12 +5,14 @@
 \alias{data_key}
 \title{User commands}
 \usage{
-data_request_access(path_data, path_user = NULL, quiet = FALSE)
+data_request_access(path_data = NULL, path_user = NULL, quiet = FALSE)
 
-data_key(path_data, path_user = NULL, test = TRUE, quiet = FALSE)
+data_key(path_data = NULL, path_user = NULL, test = TRUE, quiet = FALSE)
 }
 \arguments{
-\item{path_data}{Path to the data}
+\item{path_data}{Path to the data.  If not given, then we look
+recursively down below the working directory for a ".cyphr"
+directory, and use that as the data directory.}
 
 \item{path_user}{Path to the directory with your user key.
 Usually this can be omitted.  Use the \code{cyphr.user.path}

--- a/man/keypair_openssl.Rd
+++ b/man/keypair_openssl.Rd
@@ -4,8 +4,13 @@
 \alias{keypair_openssl}
 \title{Asymmetric encryption with openssl}
 \usage{
-keypair_openssl(pub, key, envelope = TRUE, password = NULL,
-  authenticated = TRUE)
+keypair_openssl(
+  pub,
+  key,
+  envelope = TRUE,
+  password = NULL,
+  authenticated = TRUE
+)
 }
 \arguments{
 \item{pub}{An openssl public key.  Usually this will be the path

--- a/tests/testthat/helper-cyphr.R
+++ b/tests/testthat/helper-cyphr.R
@@ -43,3 +43,9 @@ unzip_reference <- function(zip) {
   stopifnot(length(files) == 1)
   file.path(tmp, files)
 }
+
+with_dir <- function(path, code) {
+  owd <- setwd(path)
+  on.exit(setwd(owd))
+  force(code)
+}


### PR DESCRIPTION
As it was, cyphr did not work from subdirectories without manually fully specifying the path down (e.g., `cyphr::data_key("../../")`) which does not work in orderly well as there are at least two possibilities there.

This PR adds a recursive search.  It's a bit janky but the interface is at least ok and we can tidy up the implementation later (orderly uses a root/locate pair, which is slightly better but not perfect - we probably should pick up a dependency on rprojroot but I'd rather not at this point)