### PR TITLE
reside-108: more friendly messages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## cyphr 1.0.6
 
-* Added wrappers for `readxl::read_excel` and `writexl::write_xlsx`
+* Added wrappers for `readxl::read_excel` and `writexl::write_xlsx` (reside-109)
+* Support for custom messages during requesting and authorising access to data (reside-108)
 
 ## cyphr 1.0.1
 

--- a/R/data.R
+++ b/R/data.R
@@ -485,7 +485,9 @@ data_path_request <- function(path_data) {
 data_check_path_data <- function(path_data, fail = TRUE, search = FALSE) {
   if (search && !inherits(path_data, "AsIs")) {
     path_data <-
-      find_file_descend(".cyphr", path_data %||% getwd()) %||% path_data
+      find_file_descend(".cyphr", path_data %||% getwd()) %||%
+      path_data %||%
+      getwd()
   }
   success <- file.exists(data_path_test(path_data))
   if (!success && fail) {

--- a/R/data.R
+++ b/R/data.R
@@ -416,7 +416,7 @@ data_load_sym <- function(path_data, path_user, quiet) {
 }
 
 data_access_error <- function(path_data, path_data_key) {
-  cmd <- call("data_request_access", path_data)
+  cmd <- call("data_request_access", as.character(path_data))
   cmd <- paste(deparse(cmd, getOption("width", 60L)), collapse = "\n")
   msg <- paste(c("Key file not found; you may not have access",
                  sprintf("(looked in %s)", path_data_key),

--- a/R/data.R
+++ b/R/data.R
@@ -132,7 +132,7 @@ data_admin_init <- function(path_data, path_user = NULL, quiet = FALSE) {
     dat <- data_pub_load(hash, data_path_request(path_data))
     data_authorise_write(path_data, sym, dat, TRUE, quiet)
 
-    dir.create(data_path_template(path_data))
+    dir.create(data_path_template(path_data), FALSE, TRUE)
     file_copy(cyphr_file("template/README.md"),
               file.path(data_path_cyphr(path_data), "README.md"))
     file_copy(cyphr_file("template/template_request"),

--- a/R/data.R
+++ b/R/data.R
@@ -131,9 +131,17 @@ data_admin_init <- function(path_data, path_user = NULL, quiet = FALSE) {
     ## load the symmetric key from the files we're trying to write!
     dat <- data_pub_load(hash, data_path_request(path_data))
     data_authorise_write(path_data, sym, dat, TRUE, quiet)
+
+    dir.create(data_path_template(path_data))
+    file_copy(cyphr_file("template/README.md"),
+              file.path(data_path_cyphr(path_data), "README.md"))
+    file_copy(cyphr_file("template/template_request"),
+              file.path(data_path_template(path_data), "request"))
+    file_copy(cyphr_file("template/template_authorise"),
+              file.path(data_path_template(path_data), "authorise"))
   } else {
     path_data <- found
-    workflow_log(quiet, "Already set up at ", path_data)
+    workflow_log(quiet, paste("Already set up at", path_data))
   }
 
   workflow_log(quiet, "Verifying")
@@ -174,15 +182,13 @@ data_admin_authorise <- function(path_data = NULL, hash = NULL,
   }
   nok <- length(keys) - nerr
   if (nok > 0) {
-    workflow_log(quiet, "Added %d key%s", nok, ngettext(nok, "", "s"))
-    if (using_git(path_data)) {
+    workflow_log(quiet, sprintf("Added %d key%s", nok, ngettext(nok, "", "s")))
+    p <- file.path(data_path_template(path_data), "authorise")
+    if (file.exists(p)) {
       users <- paste(vapply(keys, function(x) x$user, character(1)),
                      collapse = ", ")
-      msg <- c("If you are using git, you will need to commit and push:",
-               "    git add .cyphr",
-               sprintf('    git commit -m "Authorised %s"', users),
-               '    git push')
-      workflow_log(quiet, paste(msg, collapse = "\n"))
+      msg <- gsub("$USERS", users, readLines(p), fixed = TRUE)
+      workflow_log(quiet, msg)
     }
   }
   if (nerr > 0L) {
@@ -286,22 +292,13 @@ data_request_access <- function(path_data = NULL, path_user = NULL,
     data_key_save(dat, dest)
   }
 
-  ## The idea here is that they will email or whatever creating a
-  ## second line of communication.  Probably this should provide a
-  ## hash of the request to the validity of the request can be
-  ## checked.  But I'm not really anticipating attacks here.
-  ##
-  ## Consider taking same approach as whoami, but falling back on
-  ## asking instead?
-  workflow_log(quiet, "Email someone with access to add you.")
-  workflow_log(quiet, paste0("\thash: ", bin2str(hash, ":")))
-  if (using_git(path_data)) {
-    msg <- c("If you are using git, you will need to commit and push first:",
-             "    git add .cyphr",
-             '    git commit -m "Please add me to the dataset"',
-             '    git push')
-    workflow_log(quiet, paste(msg, collapse = "\n"))
+  hash_str <- bin2str(hash, ":")
+  p <- file.path(data_path_template(path_data), "request")
+  if (file.exists(p)) {
+    msg <- gsub("$HASH", hash_str, readLines(p), fixed = TRUE)
+    workflow_log(quiet, msg)
   }
+
   invisible(hash)
 }
 
@@ -325,7 +322,7 @@ data_key <- function(path_data = NULL, path_user = NULL, test = TRUE,
 ## overwrite without warning or notice.
 data_authorise_write <- function(path_data, sym, dat, yes = FALSE,
                                  quiet = FALSE) {
-  workflow_log(quiet, "Adding key %s", data_key_str(dat))
+  workflow_log(quiet, sprintf("Adding key %s", data_key_str(dat)))
   if (!(yes || prompt_confirm())) {
     msg <- paste("Cancelled adding key ", bin2str((dat$hash)))
     e <- structure(list(message = msg, call = NULL),
@@ -435,9 +432,9 @@ data_test <- function(x, path_data) {
   }
 }
 
-workflow_log <- function(quiet, ...) {
+workflow_log <- function(quiet, msg) {
   if (!quiet) {
-    message(sprintf(...))
+    message(paste(msg, collapse = "\n"))
   }
 }
 
@@ -476,6 +473,10 @@ data_path_test <- function(path_data) {
   file.path(data_path_cyphr(path_data), "test")
 }
 
+data_path_template <- function(path_data) {
+  file.path(data_path_cyphr(path_data), "template")
+}
+
 ## A directory for data access requests
 data_path_request <- function(path_data) {
   file.path(data_path_cyphr(path_data), "requests")
@@ -497,11 +498,9 @@ data_load_request <- function(path_data, hash = NULL, quiet = FALSE) {
   path_req <- data_path_request(path_data)
   if (is.null(hash)) {
     keys <- data_admin_list_requests(I(path_data))
-    nk <- length(keys)
-    workflow_log(
-      quiet,
-      ngettext(nk, "There is 1 request for access",
-               sprintf("There are %d requests for access", nk)))
+    n <- length(keys)
+    what <- ngettext(n, "request", "requests")
+    workflow_log(quiet, sprintf("There is %d %s request for access", n, what))
   } else {
     if (is.character(hash)) {
       keys <- lapply(hash, data_pub_load, path_req)

--- a/R/data.R
+++ b/R/data.R
@@ -500,7 +500,7 @@ data_load_request <- function(path_data, hash = NULL, quiet = FALSE) {
     keys <- data_admin_list_requests(I(path_data))
     n <- length(keys)
     what <- ngettext(n, "request", "requests")
-    workflow_log(quiet, sprintf("There is %d %s request for access", n, what))
+    workflow_log(quiet, sprintf("There is %d %s for access", n, what))
   } else {
     if (is.character(hash)) {
       keys <- lapply(hash, data_pub_load, path_req)

--- a/R/openssl.R
+++ b/R/openssl.R
@@ -172,7 +172,7 @@ openssl_find_key <- function(path) {
     ## NOTE: same logic as the openssl package
     path <- Sys.getenv("USER_KEY", "~/.ssh/id_rsa")
     if (!file.exists(path)) {
-      stop("Did not find default ssh private key at ", path)
+      openssl_key_error(path, "private")
     }
   }
   if (!file.exists(path)) {
@@ -195,7 +195,7 @@ openssl_find_pubkey <- function(path) {
     ## private key which would trigger a password request).
     path <- Sys.getenv("USER_PUBKEY", "~/.ssh/id_rsa.pub")
     if (!file.exists(path)) {
-      stop("Did not find default ssh public key at ", path)
+      openssl_key_error(path, "public")
     }
   }
   if (!file.exists(path)) {
@@ -208,6 +208,13 @@ openssl_find_pubkey <- function(path) {
     }
   }
   path
+}
+
+openssl_key_error <- function(path, type) {
+  msg <- c(sprintf("Did not find default ssh %s key at '%s'", type, path),
+           "You can create a key here by running",
+           sprintf('  cyphr::ssh_keygen("%s")', path))
+  stop(paste(msg, collapse = "\n"), call. = FALSE)
 }
 
 ## -- utilities --

--- a/R/util.R
+++ b/R/util.R
@@ -111,11 +111,6 @@ find_file_descend <- function(target, start = ".", limit = "/") {
   ret
 }
 
-using_git <- function(path) {
-  tryCatch(!is.null(find_file_descend(".git", path)),
-           error = function(e) FALSE)
-}
-
 ## Replace with ask once it's on CRAN?
 prompt_confirm <- function(msg = "continue?", valid = c(n = FALSE, y = TRUE),
                            default = names(valid)[[1]]) {

--- a/R/util.R
+++ b/R/util.R
@@ -144,3 +144,11 @@ read_line <- function(prompt) {
 `%||%` <- function(a, b) {
   if (is.null(a)) b else a
 }
+
+cyphr_file <- function(...) {
+  system.file(..., package = "cyphr", mustWork = TRUE)
+}
+
+file_copy <- function(...) {
+  stopifnot(file.copy(...))
+}

--- a/inst/template/README.md
+++ b/inst/template/README.md
@@ -3,7 +3,7 @@
 This directory is used by `cyphr` and contains:
 
 * `test` - a small file used to test whether encryption/decrpytion is possible with your key
-* Files in `355b345588dc82385acf1cab30ee160e` which are encrypted copies of the (symmetric) data key, encrypted with different users' private keys.  The filename is based on the fingerprint of the private key (see `?openssl::fingerprint`)
+* Files like `355b345588dc82385acf1cab30ee160e` which are encrypted copies of the (symmetric) data key, encrypted with different users' private keys.  The filename is based on the fingerprint of the private key (see `?openssl::fingerprint`)
 * Files in `requests` which are pending requests for access
 
 ### Templates

--- a/inst/template/README.md
+++ b/inst/template/README.md
@@ -9,3 +9,5 @@ This directory is used by `cyphr` and contains:
 ### Templates
 
 You can create files `template_request` and `template_authorise` within this directory and they will be used to provide feedback when requesting access and authorising keys.  Because this step requires some out-of-band communication this can be useful.
+
+Within the `template_request` template the string `$HASH` will be substituted for your key's hash, and within `template_authorise` the string `$USERS` will contain the usernames of added users.

--- a/inst/template/README.md
+++ b/inst/template/README.md
@@ -3,11 +3,11 @@
 This directory is used by `cyphr` and contains:
 
 * `test` - a small file used to test whether encryption/decrpytion is possible with your key
-* Files like `355b345588dc82385acf1cab30ee160e` which are encrypted copies of the (symmetric) data key, encrypted with different users' private keys.  The filename is based on the fingerprint of the private key (see `?openssl::fingerprint`)
-* Files in `requests` which are pending requests for access
+* Files in `keys/` are encrypted copies of the (symmetric) data key, encrypted with different users' private keys.  The filename is based on the fingerprint of the private key (see `?openssl::fingerprint`)
+* Files in `requests/` which are pending requests for access
 
 ### Templates
 
-You can create files `template_request` and `template_authorise` within this directory and they will be used to provide feedback when requesting access and authorising keys.  Because this step requires some out-of-band communication this can be useful.
+You can edit the files `template/request` and `template/authorise` and they will be used to provide feedback when requesting access and authorising keys.  Because this step requires some out-of-band communication this can be useful.
 
-Within the `template_request` template the string `$HASH` will be substituted for your key's hash, and within `template_authorise` the string `$USERS` will contain the usernames of added users.
+Within the `template/request` template the string `$HASH` will be substituted for your key's hash, and within `template/authorise` the string `$USERS` will contain the usernames of added users.

--- a/inst/template/README.md
+++ b/inst/template/README.md
@@ -1,0 +1,11 @@
+## cyphr internal structures
+
+This directory is used by `cyphr` and contains:
+
+* `test` - a small file used to test whether encryption/decrpytion is possible with your key
+* Files in `355b345588dc82385acf1cab30ee160e` which are encrypted copies of the (symmetric) data key, encrypted with different users' private keys.  The filename is based on the fingerprint of the private key (see `?openssl::fingerprint`)
+* Files in `requests` which are pending requests for access
+
+### Templates
+
+You can create files `template_request` and `template_authorise` within this directory and they will be used to provide feedback when requesting access and authorising keys.  Because this step requires some out-of-band communication this can be useful.

--- a/inst/template/template_authorise
+++ b/inst/template/template_authorise
@@ -1,0 +1,5 @@
+If you are using git, you will need to commit and push:
+
+    git add .cyphr
+    git commit -m "Authorised $USERS"
+    git push

--- a/inst/template/template_request
+++ b/inst/template/template_request
@@ -1,0 +1,9 @@
+Email someone with access to add you
+
+    hash: $HASH
+
+If you are using git, you will need to commit and push first:
+
+    git add .cyphr
+    git commit -m "Please add me to the dataset"
+    git push

--- a/tests/testthat/test-zzz-data.R
+++ b/tests/testthat/test-zzz-data.R
@@ -247,3 +247,29 @@ test_that("Work from a subdirectory", {
   k2 <- with_dir(sub, data_key(path_user = pair2))
   expect_identical(k1$key(), k2$key())
 })
+
+
+test_that("Custom messages", {
+  path <- tempfile()
+  dir.create(path, FALSE, TRUE)
+  res <- data_admin_init(path, "pair1", TRUE)
+
+  writeLines("my custom $HASH request message",
+             file.path(data_path_template(path), "request"))
+  writeLines("my custom $USERS authorise message",
+             file.path(data_path_template(path), "authorise"))
+
+  res1 <- testthat::evaluate_promise(
+    data_request_access(path, "pair2"))
+  res2 <- testthat::evaluate_promise(
+    data_admin_authorise(path, res1$result, "pair1", TRUE))
+
+  expect_match(
+    res1$messages,
+    "my custom [[:xdigit:]:]+ request message",
+    all = FALSE)
+  expect_match(
+    res2$messages,
+    "my custom .+ authorise message",
+    all = FALSE)
+})

--- a/tests/testthat/test-zzz-data.R
+++ b/tests/testthat/test-zzz-data.R
@@ -123,6 +123,12 @@ test_that("not set up", {
   path <- tempfile()
   dir.create(path, FALSE, TRUE)
   expect_error(data_key(path, "pair2"), "cyphr not set up for")
+  expect_error(
+    with_dir(path, data_key(NULL, "pair2")),
+    "cyphr not set up for")
+  expect_error(
+    with_dir(path, data_key(path_user = "pair2")),
+    "cyphr not set up for")
   res <- data_admin_init(path, "pair1")
   expect_error(data_key(path, "pair2"),
                "Key file not found; you may not have access")


### PR DESCRIPTION
This PR adds support for customisable template messages on requesting and authorising keys.  Along the same vein it adds an improved error message when a ssh key cannot be found