### PR TITLE
reside-109: add excel rewrite rules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cyphr
 Title: High Level Encryption Wrappers
-Version: 1.0.5
+Version: 1.0.6
 Authors@R: person("Rich", "FitzJohn", role = c("aut", "cre"),
     email = "rich.fitzjohn@gmail.com")
 Description: Encryption wrappers, using low-level support from

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## cyphr 1.0.6
+
+* Added wrappers for `readxl::read_excel` and `writexl::write_excel`
+
 ## cyphr 1.0.1
 
 * First CRAN release

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## cyphr 1.0.6
 
-* Added wrappers for `readxl::read_excel` and `writexl::write_excel`
+* Added wrappers for `readxl::read_excel` and `writexl::write_xlsx`
 
 ## cyphr 1.0.1
 

--- a/R/encrypt_wrapper.R
+++ b/R/encrypt_wrapper.R
@@ -320,5 +320,7 @@ rewrite_reset <- function() {
   rewrite_register("utils", "read.delim2", "file")
   ## Other useful things
   rewrite_register("readxl",  "read_excel", "path")
+  rewrite_register("readxl",  "read_xlsx",  "path")
+  rewrite_register("readxl",  "read_xls",   "path")
   rewrite_register("writexl", "write_xlsx", "path")
 }

--- a/R/encrypt_wrapper.R
+++ b/R/encrypt_wrapper.R
@@ -318,4 +318,7 @@ rewrite_reset <- function() {
   rewrite_register("utils", "write.csv2",  "file", c("utils", "write.table"))
   rewrite_register("utils", "read.delim",  "file")
   rewrite_register("utils", "read.delim2", "file")
+  ## Other useful things
+  rewrite_register("readxl",  "read_excel", "path")
+  rewrite_register("writexl", "write_xlsx", "path")
 }

--- a/tests/testthat/test-rewrite.R
+++ b/tests/testthat/test-rewrite.R
@@ -30,7 +30,7 @@ test_that("command rewriting", {
                "Cannot infer file argument")
   expect_error(rewrite(quote(unknown("myfile"))))
   expect_error(rewrite(quote(plot("myfile"))),
-               "Rewrite rule for graphics::plot not found", fixed = TRUE)
+               "Rewrite rule for .*::plot not found", fixed = TRUE)
 })
 
 test_that("filename default argument", {

--- a/tests/testthat/test-rewrite.R
+++ b/tests/testthat/test-rewrite.R
@@ -30,7 +30,7 @@ test_that("command rewriting", {
                "Cannot infer file argument")
   expect_error(rewrite(quote(unknown("myfile"))))
   expect_error(rewrite(quote(plot("myfile"))),
-               "Rewrite rule for .*::plot not found", fixed = TRUE)
+               "Rewrite rule for .*::plot not found")
 })
 
 test_that("filename default argument", {


### PR DESCRIPTION
Adds rewrite rules for handling of excel files.  These are not tested as that would require a dependency that we don't need.

This fixes a change in R-devel (plot is apparently moving into base!?), which will require a package resubmission to CRAN soon...