### PR TITLE
reside-111: Cache key within session

### DIFF
--- a/man/data_user.Rd
+++ b/man/data_user.Rd
@@ -7,7 +7,13 @@
 \usage{
 data_request_access(path_data = NULL, path_user = NULL, quiet = FALSE)
 
-data_key(path_data = NULL, path_user = NULL, test = TRUE, quiet = FALSE)
+data_key(
+  path_data = NULL,
+  path_user = NULL,
+  test = TRUE,
+  quiet = FALSE,
+  cache = TRUE
+)
 }
 \arguments{
 \item{path_data}{Path to the data.  If not given, then we look
@@ -22,6 +28,12 @@ conveniently.}
 \item{quiet}{Suppress printing of informative messages.}
 
 \item{test}{Test that the encryption is working?  (Recommended)}
+
+\item{cache}{Cache the key within the session.  This will be
+useful if you are using ssh keys that have passwords, as if the
+key is found within the cache, then you will not have to
+re-enter your password.  Using \code{cache = FALSE} neither
+looks for the key in the cache, nor saves it.}
 }
 \description{
 User commands

--- a/tests/testthat/test-zzz-data.R
+++ b/tests/testthat/test-zzz-data.R
@@ -369,3 +369,16 @@ test_that("new data sources do not need migrating", {
   res <- testthat::evaluate_promise(data_schema_migrate(path))
   expect_match(res$messages, "Everything up to date!")
 })
+
+
+test_that("cache data key", {
+  path <- tempfile()
+  dir.create(path, FALSE)
+  data_admin_init(path, "pair1")
+
+  key1 <- data_key(path, "pair1")
+  key2 <- data_key(path, "pair1")
+  key3 <- data_key(path, "pair1", cache = FALSE)
+  expect_identical(key1, key2)
+  expect_false(identical(key1, key3))
+})


### PR DESCRIPTION
This enables the data key to the cached, one key per target
directory, which prevents the requirement to load the ssh
private key (which should be password protected)